### PR TITLE
Clarify link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ And write this instead:
  	  .onLeftArrowKeyDown(previousPage)
 	  .onRightArrowKeyDown(nextPage);
 
-Read more about easykeyjs [here](http://www.blinkingcaret.com/2016/02/24/easykeyjs)
+Read [more about easykeyjs](http://www.blinkingcaret.com/2016/02/24/easykeyjs).
 
-Go download the latest version [http://easykeyjs.com](http://easykeyjs.com)
+Go download the latest version [http://easykeyjs.com](http://easykeyjs.com).


### PR DESCRIPTION
Links should have a text label that conveys what the document they link to is about; “here”, “click here”, “read more”, etc don't suffice.
