### PR TITLE
Fix errors and missing semicolons and improve code

### DIFF
--- a/easyKey.js
+++ b/easyKey.js
@@ -1,360 +1,361 @@
 (function($){
-	$.easyKey = $.easyKey || {};
-	$.easyKey.keyCodes =  $.easyKey.keyCodes || { 
-		"backspace":8,
-		"tab":9,
-		"enter":13,
-		"shift":16,
-		"ctrl":17,
-		"alt":18,
-		"pause_break":19,
-		"caps_lock":20,
-		"escape":27,
+	'use strict';
+	$.easykey = $.easykey || {};
+	$.easykey.keycodes =  $.easykey.keycodes || {
+		"backspace": 8,
+		"tab": 9,
+		"enter": 13,
+		"shift": 16,
+		"ctrl": 17,
+		"alt": 18,
+		"pause_break": 19,
+		"caps_lock": 20,
+		"escape": 27,
 		"space": 32,
-		"page_up":33,
-		"page_down":34,
-		"end":35,
-		"home":36,
-		"left_arrow":37,
-		"up_arrow":38,
-		"right_arrow":39,
-		"down_arrow":40,
-		"insert":45,
-		"delete":46,
-		"0":48,
-		"1":49,
-		"2":50,
-		"3":51,
-		"4":52,
-		"5":53,
-		"6":54,
-		"7":55,
-		"8":56,
-		"9":57,
-		"a":65,
-		"b":66,
-		"c":67,
-		"d":68,
-		"e":69,
-		"f":70,
-		"g":71,
-		"h":72,
-		"i":73,
-		"j":74,
-		"k":75,
-		"l":76,
-		"m":77,
-		"n":78,
-		"o":79,
-		"p":80,
-		"q":81,
-		"r":82,
-		"s":83,
-		"t":84,
-		"u":85,
-		"v":86,
-		"w":87,
-		"x":88,
-		"y":89,
-		"z":90,
-		"left_window_key":91,
-		"right_window_key":92,
-		"select_key":93,
-		"numpad_0":96,
-		"numpad_1":97,
-		"numpad_2":98,
-		"numpad_3":99,
-		"numpad_4":100,
-		"numpad_5":101,
-		"numpad_6":102,
-		"numpad_7":103,
-		"numpad_8":104,
-		"numpad_9":105,
-		"multiply":106,
-		"add":107,
-		"subtract":109,
-		"decimal_point":110,
-		"divide":111,
-		"f1":112,
-		"f2":113,
-		"f3":114,
-		"f4":115,
-		"f5":116,
-		"f6":117,
-		"f7":118,
-		"f8":119,
-		"f9":120,
-		"f10":121,
-		"f11":122,
-		"f12":123,
-		"num_lock":144,
-		"scroll_lock":145,
-		"semi_colon,":186,
-		"equal_sign":187,
-		"comma":188,
-		"dash":189,
-		"period":190,
-		"forward_slash":191,
-		"grave_accent":192,
-		"open_bracket":219,
-		"back_slash":220,
-		"close_braket":221,
-		"single_quote":222 };
+		"page_up": 33,
+		"page_down": 34,
+		"end": 35,
+		"home": 36,
+		"left_arrow": 37,
+		"up_arrow": 38,
+		"right_arrow": 39,
+		"down_arrow": 40,
+		"insert": 45,
+		"delete": 46,
+		"0": 48,
+		"1": 49,
+		"2": 50,
+		"3": 51,
+		"4": 52,
+		"5": 53,
+		"6": 54,
+		"7": 55,
+		"8": 56,
+		"9": 57,
+		"a": 65,
+		"b": 66,
+		"c": 67,
+		"d": 68,
+		"e": 69,
+		"f": 70,
+		"g": 71,
+		"h": 72,
+		"i": 73,
+		"j": 74,
+		"k": 75,
+		"l": 76,
+		"m": 77,
+		"n": 78,
+		"o": 79,
+		"p": 80,
+		"q": 81,
+		"r": 82,
+		"s": 83,
+		"t": 84,
+		"u": 85,
+		"v": 86,
+		"w": 87,
+		"x": 88,
+		"y": 89,
+		"z": 90,
+		"left_window_key": 91,
+		"right_window_key": 92,
+		"select_key": 93,
+		"numpad_0": 96,
+		"numpad_1": 97,
+		"numpad_2": 98,
+		"numpad_3": 99,
+		"numpad_4": 100,
+		"numpad_5": 101,
+		"numpad_6": 102,
+		"numpad_7": 103,
+		"numpad_8": 104,
+		"numpad_9": 105,
+		"multiply": 106,
+		"add": 107,
+		"subtract": 109,
+		"decimal_point": 110,
+		"divide": 111,
+		"f1": 112,
+		"f2": 113,
+		"f3": 114,
+		"f4": 115,
+		"f5": 116,
+		"f6": 117,
+		"f7": 118,
+		"f8": 119,
+		"f9": 120,
+		"f10": 121,
+		"f11": 122,
+		"f12": 123,
+		"num_lock": 144,
+		"scroll_lock": 145,
+		"semi_colon,": 186,
+		"equal_sign": 187,
+		"comma": 188,
+		"dash": 189,
+		"period": 190,
+		"forward_slash": 191,
+		"grave_accent": 192,
+		"open_bracket": 219,
+		"back_slash": 220,
+		"close_braket": 221,
+		"single_quote": 222
+	};
 
 
-	$.easyKey.options = {
+	$.easykey.options = {
 		onKeyDown : 1,
 		onKeyUp: 2,
 		withShiftPressed: 4,
 		withControlPressed: 8,
 		withAltPressed: 16
 	};
-	
 
-	$.fn.onKey = function(whichKey, onKey, options){		
+
+	$.fn.onKey = function(key, handler, options){
 		var hasOption = function(option){
 			if (option == void 0) throw new Error("No option was specified");
-			return (options & option) === option;	
+			return (options & option) === option;
 		};
 
 		var shouldHandleKey = function(event, keyCodeToHandle){
 			var keyPressedCode = event.which;
 
 			if (keyPressedCode != keyCodeToHandle)
-				return false;			
-
-			if ((hasOption($.easyKey.options.withShiftPressed) && !event.shiftKey) || (!hasOption($.easyKey.options.withShiftPressed) && event.shiftKey))
 				return false;
 
-			if ((hasOption($.easyKey.options.withControlPressed) && !event.ctrlKey) || (!hasOption($.easyKey.options.withControlPressed) && event.ctrlKey))
+			if ((hasOption($.easykey.options.withShiftPressed) && !event.shiftKey) || (!hasOption($.easykey.options.withShiftPressed) && event.shiftKey))
 				return false;
 
-			if ((hasOption($.easyKey.options.withAltPressed) && !event.altKey) || (!hasOption($.easyKey.options.withAltPressed) && event.altKey))
-				return false;			
+			if ((hasOption($.easykey.options.withControlPressed) && !event.ctrlKey) || (!hasOption($.easykey.options.withControlPressed) && event.ctrlKey))
+				return false;
+
+			if ((hasOption($.easykey.options.withAltPressed) && !event.altKey) || (!hasOption($.easykey.options.withAltPressed) && event.altKey))
+				return false;
 
 			return true;
 		};
 
 		if (options == void 0)
-			options = $.easyKey.options.onKeyDown;
+			options = $.easykey.options.onKeyDown;
 
 		this.each(function(){
-			if (hasOption($.easyKey.options.onKeyDown)){
-				$(this).keydown(function(e){					
-					if (shouldHandleKey(e, whichKey)){
-						return onKey.call(this, e);
+			if (hasOption($.easykey.options.onKeyDown)){
+				$(this).keydown(function(e){
+					if (shouldHandleKey(e, key)){
+						return handler.call(this, e);
 					}
 				});
 			}
-			if (hasOption($.easyKey.options.onKeyUp)){
+			if (hasOption($.easykey.options.onKeyUp)){
 				$(this).keyup(function(e){
-					if (shouldHandleKey(e, whichKey)){
-						return onKey.call(this, e);
+					if (shouldHandleKey(e, key)){
+						return handler.call(this, e);
 					}
-				});				
+				});
 			}
 		});
 		return this;
 	};
 
-	$.fn.onBackspaceKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.backspace, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onTabKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.tab, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onEnterKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.enter, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onShiftKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.shift, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onCtrlKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.ctrl, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onAltKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.alt, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onPauseBreakKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.pause_break, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onCapsLockKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.caps_lock, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onEscapeKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.escape, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onSpaceKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.space, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onPageUpKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.page_up, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onPageDownKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.page_down, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onEndKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.end, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onHomeKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.home, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onLeftArrowKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.left_arrow, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onUpArrowKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.up_arrow, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onRightArrowKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.right_arrow, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onDownArrowKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.down_arrow, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onInsertKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.insert, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onDeleteKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.delete, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on0KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["0"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on1KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["1"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on2KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["2"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on3KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["3"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on4KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["4"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on5KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["5"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on6KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["6"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on7KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["7"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on8KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["8"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.on9KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["9"], onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onAKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.a, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onBKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.b, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onCKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.c, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onDKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.d, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onEKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.e, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onFKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onGKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.g, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onHKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.h, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onIKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.i, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onJKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.j, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onKKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.k, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onLKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.l, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onMKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.m, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.n, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onOKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.o, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onPKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.p, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onQKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.q, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onRKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.r, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onSKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.s, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onTKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.t, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onUKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.u, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onVKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.v, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onWKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.w, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onXKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.x, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onYKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.y, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onZKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.z, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onLeftWindowKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.left_window_key, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onRightWindowKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.right_window_key, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onSelectKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.select_key, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad0KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_0, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad1KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_1, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad2KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_2, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad3KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_3, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad4KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_4, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad5KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_5, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad6KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_6, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad7KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_7, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad8KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_8, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumpad9KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_9, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onMultiplyKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.multiply, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onAddKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.add, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onSubtractKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.subtract, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onDecimalPointKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.decimal_point, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onDivideKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.divide, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF1KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f1, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF2KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f2, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF3KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f3, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF4KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f4, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF5KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f5, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF6KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f6, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF7KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f7, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF8KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f8, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF9KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f9, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF10KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f10, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF11KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f11, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onF12KeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f12, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onNumLockKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.num_lock, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onScrollLockKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.scroll_lock, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onSemiColonKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.semi_colon, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onEqualSignKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.equal_sign, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onCommaKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.comma, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onDashKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.dash, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onPeriodKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.period, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onForwardSlashKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.forward_slash, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onGraveAccentKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.grave_accent, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onOpenBracketKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.open_bracket, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onBackSlashKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.back_slash, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onCloseBraketKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.close_braket, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
-	$.fn.onSingleQuoteKeyDown = function(onKeyDownHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.single_quote, onKeyDownHandler, $.easyKey.options.onKeyDown | options); }
+	$.fn.onBackspaceKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.backspace, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onTabKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.tab, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onEnterKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.enter, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onShiftKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.shift, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onCtrlKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.ctrl, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onAltKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.alt, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onPauseBreakKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.pause_break, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onCapsLockKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.caps_lock, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onEscapeKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.escape, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onSpaceKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.space, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onPageUpKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.page_up, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onPageDownKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.page_down, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onEndKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.end, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onHomeKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.home, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onLeftArrowKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.left_arrow, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onUpArrowKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.up_arrow, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onRightArrowKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.right_arrow, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onDownArrowKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.down_arrow, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onInsertKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.insert, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onDeleteKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.delete, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on0KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["0"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on1KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["1"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on2KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["2"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on3KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["3"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on4KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["4"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on5KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["5"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on6KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["6"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on7KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["7"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on8KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["8"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.on9KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["9"], handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onAKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.a, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onBKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.b, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onCKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.c, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onDKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.d, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onEKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.e, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onFKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onGKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.g, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onHKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.h, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onIKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.i, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onJKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.j, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onKKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.k, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onLKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.l, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onMKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.m, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.n, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onOKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.o, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onPKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.p, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onQKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.q, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onRKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.r, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onSKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.s, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onTKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.t, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onUKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.u, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onVKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.v, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onWKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.w, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onXKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.x, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onYKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.y, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onZKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.z, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onLeftWindowKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.left_window_key, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onRightWindowKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.right_window_key, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onSelectKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.select_key, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad0KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_0, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad1KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_1, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad2KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_2, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad3KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_3, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad4KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_4, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad5KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_5, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad6KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_6, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad7KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_7, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad8KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_8, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumpad9KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_9, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onMultiplyKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.multiply, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onAddKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.add, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onSubtractKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.subtract, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onDecimalPointKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.decimal_point, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onDivideKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.divide, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF1KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f1, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF2KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f2, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF3KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f3, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF4KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f4, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF5KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f5, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF6KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f6, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF7KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f7, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF8KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f8, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF9KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f9, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF10KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f10, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF11KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f11, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onF12KeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f12, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onNumLockKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.num_lock, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onScrollLockKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.scroll_lock, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onSemiColonKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.semi_colon, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onEqualSignKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.equal_sign, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onCommaKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.comma, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onDashKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.dash, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onPeriodKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.period, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onForwardSlashKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.forward_slash, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onGraveAccentKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.grave_accent, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onOpenBracketKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.open_bracket, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onBackSlashKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.back_slash, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onCloseBraketKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.close_braket, handler, $.easykey.options.onKeyDown || options); };
+	$.fn.onSingleQuoteKeyDown = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.single_quote, handler, $.easykey.options.onKeyDown || options); };
 
-	$.fn.onBackspaceKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.backspace, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onTabKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.tab, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onEnterKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.enter, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onShiftKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.shift, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onCtrlKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.ctrl, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onAltKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.alt, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onPauseBreakKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.pause_break, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onCapsLockKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.caps_lock, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onEscapeKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.escape, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onSpaceKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.space, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onPageUpKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.page_up, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onPageDownKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.page_down, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onEndKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.end, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onHomeKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.home, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onLeftArrowKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.left_arrow, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onUpArrowKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.up_arrow, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onRightArrowKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.right_arrow, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onDownArrowKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.down_arrow, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onInsertKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.insert, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onDeleteKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.delete, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on0KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["0"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on1KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["1"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on2KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["2"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on3KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["3"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on4KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["4"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on5KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["5"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on6KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["6"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on7KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["7"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on8KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["8"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.on9KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes["9"], onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onAKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.a, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onBKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.b, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onCKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.c, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onDKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.d, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onEKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.e, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onFKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onGKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.g, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onHKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.h, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onIKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.i, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onJKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.j, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onKKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.k, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onLKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.l, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onMKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.m, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.n, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onOKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.o, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onPKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.p, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onQKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.q, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onRKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.r, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onSKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.s, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onTKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.t, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onUKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.u, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onVKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.v, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onWKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.w, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onXKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.x, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onYKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.y, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onZKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.z, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onLeftWindowKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.left_window_key, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onRightWindowKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.right_window_key, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onSelectKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.select_key, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad0KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_0, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad1KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_1, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad2KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_2, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad3KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_3, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad4KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_4, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad5KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_5, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad6KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_6, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad7KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_7, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad8KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_8, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumpad9KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.numpad_9, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onMultiplyKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.multiply, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onAddKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.add, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onSubtractKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.subtract, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onDecimalPointKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.decimal_point, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onDivideKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.divide, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF1KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f1, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF2KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f2, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF3KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f3, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF4KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f4, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF5KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f5, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF6KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f6, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF7KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f7, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF8KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f8, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF9KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f9, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF10KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f10, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF11KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f11, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onF12KeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.f12, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onNumLockKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.num_lock, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onScrollLockKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.scroll_lock, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onSemiColonKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.semi_colon, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onEqualSignKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.equal_sign, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onCommaKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.comma, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onDashKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.dash, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onPeriodKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.period, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onForwardSlashKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.forward_slash, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onGraveAccentKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.grave_accent, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onOpenBracketKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.open_bracket, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onBackSlashKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.back_slash, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onCloseBraketKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.close_braket, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-	$.fn.onSingleQuoteKeyUp = function(onKeyUpHandler, options) { return $.fn.onKey.call(this, $.easyKey.keyCodes.single_quote, onKeyUpHandler, $.easyKey.options.onKeyUp | options); }
-
+	$.fn.onBackspaceKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.backspace, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onTabKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.tab, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onEnterKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.enter, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onShiftKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.shift, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onCtrlKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.ctrl, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onAltKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.alt, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onPauseBreakKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.pause_break, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onCapsLockKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.caps_lock, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onEscapeKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.escape, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onSpaceKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.space, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onPageUpKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.page_up, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onPageDownKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.page_down, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onEndKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.end, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onHomeKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.home, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onLeftArrowKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.left_arrow, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onUpArrowKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.up_arrow, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onRightArrowKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.right_arrow, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onDownArrowKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.down_arrow, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onInsertKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.insert, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onDeleteKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.delete, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on0KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["0"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on1KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["1"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on2KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["2"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on3KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["3"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on4KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["4"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on5KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["5"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on6KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["6"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on7KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["7"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on8KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["8"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.on9KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes["9"], handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onAKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.a, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onBKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.b, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onCKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.c, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onDKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.d, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onEKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.e, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onFKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onGKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.g, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onHKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.h, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onIKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.i, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onJKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.j, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onKKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.k, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onLKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.l, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onMKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.m, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.n, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onOKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.o, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onPKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.p, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onQKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.q, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onRKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.r, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onSKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.s, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onTKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.t, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onUKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.u, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onVKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.v, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onWKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.w, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onXKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.x, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onYKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.y, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onZKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.z, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onLeftWindowKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.left_window_key, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onRightWindowKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.right_window_key, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onSelectKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.select_key, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad0KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_0, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad1KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_1, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad2KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_2, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad3KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_3, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad4KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_4, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad5KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_5, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad6KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_6, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad7KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_7, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad8KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_8, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumpad9KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.numpad_9, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onMultiplyKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.multiply, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onAddKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.add, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onSubtractKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.subtract, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onDecimalPointKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.decimal_point, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onDivideKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.divide, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF1KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f1, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF2KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f2, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF3KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f3, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF4KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f4, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF5KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f5, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF6KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f6, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF7KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f7, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF8KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f8, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF9KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f9, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF10KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f10, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF11KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f11, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onF12KeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.f12, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onNumLockKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.num_lock, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onScrollLockKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.scroll_lock, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onSemiColonKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.semi_colon, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onEqualSignKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.equal_sign, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onCommaKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.comma, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onDashKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.dash, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onPeriodKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.period, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onForwardSlashKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.forward_slash, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onGraveAccentKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.grave_accent, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onOpenBracketKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.open_bracket, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onBackSlashKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.back_slash, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onCloseBraketKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.close_braket, handler, $.easykey.options.onKeyUp || options); };
+	$.fn.onSingleQuoteKeyUp = function(handler, options) { return $.fn.onKey.call(this, $.easykey.keycodes.single_quote, handler, $.easykey.options.onKeyUp || options); };
 }(jQuery));


### PR DESCRIPTION
**1. changed redundant variable and parameter names**
For instance, `onKeyDownHandler` and `onKeyUpHandler` parameters have been changed to just `handler`. They are unnecessarily verbose because the event type (key down or key up) is already mentioned in the function name (eg., `onBackspaceKeyDown`)

**2. fixed missing semicolons and some other, more minor errors**
Probably the most important fix; the functions were missing semicolons.

**3. changed `easyKey` (note the camelcase) to `easykey`**
In my opinion, `easykey` is significantly easier to type.
